### PR TITLE
Fix duplicate classname unique resourcetypename

### DIFF
--- a/src/Bicep.LocalDeploy.DocGenerator.Tests/DocGeneratorTests.cs
+++ b/src/Bicep.LocalDeploy.DocGenerator.Tests/DocGeneratorTests.cs
@@ -11,7 +11,7 @@ public class DocGeneratorTests
 {
     private static string ReadFile(string path) => File.ReadAllText(path, Encoding.UTF8);
 
-    private static async Task<string> GenerateMarkdownAsync(string csSource, string h1Contains)
+    private static async Task<Dictionary<string, string>> GenerateMarkdownFilesAsync(string csSource)
     {
         DirectoryInfo outDir = Directory.CreateTempSubdirectory("docgen-out-");
         DirectoryInfo srcDir = Directory.CreateTempSubdirectory("docgen-src-");
@@ -32,16 +32,13 @@ public class DocGeneratorTests
             await DocumentationGenerator.GenerateAsync(options);
 
             string[] files = Directory.GetFiles(outDir.FullName, "*.md");
-            Assert.That(files, Is.Not.Empty, "No markdown files were generated");
-            foreach (string f in files)
+
+            var results = new Dictionary<string, string>();
+            foreach (string file in files)
             {
-                string content = ReadFile(f);
-                if (content.Contains("# " + h1Contains, StringComparison.Ordinal))
-                {
-                    return content;
-                }
+                results.Add(file, ReadFile(file));
             }
-            return ReadFile(files.First());
+            return results;
         }
         finally
         {
@@ -60,6 +57,19 @@ public class DocGeneratorTests
             { /* ignore */
             }
         }
+    }
+
+    private static async Task<string> GenerateMarkdownAsync(string csSource, string h1Contains)
+    {
+        var output = await GenerateMarkdownFilesAsync(csSource);
+        foreach (var file in output)
+        {
+            if (file.Value.Contains("# " + h1Contains, StringComparison.Ordinal))
+            {
+                return file.Value;
+            }
+        }
+        return output.Values.First();
     }
 
     [Test]
@@ -378,5 +388,39 @@ public class EnumMany
 
         string md = await GenerateMarkdownAsync(cs, "EnumMany");
         Assert.That(md, Does.Contain("(Can be `A`, `B`, or `C`)"));
+    }
+
+
+    [Test]
+    public async Task DuplicateClassNameUniqueResourceNames()
+    {
+        string cs = """
+using Bicep.LocalDeploy;
+using Bicep.Local.Extension.Types.Attributes;
+
+namespace MyExt.ModelA
+{
+    [ResourceType("ModelA.SimpleResource")]
+    public class SimpleResource
+    {
+        [TypeProperty("Simple Value.", ObjectTypePropertyFlags.None)]
+        public string? Value { get; set; }
+    }
+}
+
+namespace MyExt.ModelB
+{
+    [ResourceType("ModelB.SimpleResource")]
+    public class SimpleResource
+    {
+        [TypeProperty("Simple Value.", ObjectTypePropertyFlags.None)]
+        public string? Value { get; set; }
+    }
+}
+""";
+        var outputFiles = await GenerateMarkdownFilesAsync(cs);
+
+        Assert.That(outputFiles, Has.Exactly(1).Matches<KeyValuePair<string, string>>(kv => kv.Value.Contains("# ModelA.SimpleResource", StringComparison.OrdinalIgnoreCase)));
+        Assert.That(outputFiles, Has.Exactly(1).Matches<KeyValuePair<string, string>>(kv => kv.Value.Contains("# ModelB.SimpleResource", StringComparison.OrdinalIgnoreCase)));
     }
 }

--- a/src/Bicep.LocalDeploy.DocGenerator.Tests/DocGeneratorTests.cs
+++ b/src/Bicep.LocalDeploy.DocGenerator.Tests/DocGeneratorTests.cs
@@ -403,8 +403,8 @@ namespace MyExt.ModelA
     [ResourceType("ModelA.SimpleResource")]
     public class SimpleResource
     {
-        [TypeProperty("Simple Value.", ObjectTypePropertyFlags.None)]
-        public string? Value { get; set; }
+        [TypeProperty("Simple Value A", ObjectTypePropertyFlags.None)]
+        public string? ValueA { get; set; }
     }
 }
 
@@ -413,8 +413,8 @@ namespace MyExt.ModelB
     [ResourceType("ModelB.SimpleResource")]
     public class SimpleResource
     {
-        [TypeProperty("Simple Value.", ObjectTypePropertyFlags.None)]
-        public string? Value { get; set; }
+        [TypeProperty("Simple Value B", ObjectTypePropertyFlags.None)]
+        public string? ValueB { get; set; }
     }
 }
 """;

--- a/src/Bicep.LocalDeploy.DocGenerator/Services/DocumentationGenerator.cs
+++ b/src/Bicep.LocalDeploy.DocGenerator/Services/DocumentationGenerator.cs
@@ -37,10 +37,9 @@ namespace Bicep.LocalDeploy.DocGenerator.Services
             }
 
             // Build lookup for type nesting
-            IReadOnlyDictionary<string, TypeInfoModel> typeLookup = analysis.Types.ToDictionary(
-                t => t.Name,
-                t => t
-            );
+            IReadOnlyDictionary<string, TypeInfoModel> typeLookup = analysis
+                .Types.GroupBy(t => t.Name)
+                .ToDictionary(g => g.Key, g => g.First());
 
             foreach (TypeInfoModel type in resources)
             {


### PR DESCRIPTION
If a codebase has 2 resources, like this:

```cs
namespace MyExt.ModelA
{
    [ResourceType("ModelA.SimpleResource")]
    public class SimpleResource
    {
        [TypeProperty("Simple Value.", ObjectTypePropertyFlags.None)]
        public string? Value { get; set; }
    }
}
namespace MyExt.ModelB
{
    [ResourceType("ModelB.SimpleResource")]
    public class SimpleResource
    {
        [TypeProperty("Simple Value.", ObjectTypePropertyFlags.None)]
        public string? Value { get; set; }
    }
}
```


would cause an exception to be thrown here:

https://github.com/Gijsreyn/bicep-local-docgen/blob/da7bd68deffc6998b67411baf3f724afc0189c57/src/Bicep.LocalDeploy.DocGenerator/Services/DocumentationGenerator.cs#L39-L43


Stacktrace

```cs
System.ArgumentException : An item with the same key has already been added. Key: SimpleResource
at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
at System.Linq.Enumerable.SpanToDictionary[TSource,TKey,TElement](ReadOnlySpan`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector)
at Bicep.LocalDeploy.DocGenerator.Services.DocumentationGenerator.GenerateAsync(GenerationOptions options) (file:///bicep-local-docgen/src/Bicep.LocalDeploy.DocGenerator/Services/DocumentationGenerator.cs#L41,0)
at Bicep.LocalDeploy.DocGenerator.Tests.DocGeneratorTests.GenerateMarkdownFilesAsync(String csSource) (file:///bicep-local-docgen/src/Bicep.LocalDeploy.DocGenerator.Tests/DocGeneratorTests.cs#L33,0)
at Bicep.LocalDeploy.DocGenerator.Tests.DocGeneratorTests.DuplicateClassNameUniqueResourceNames() (file:///bicep-local-docgen/src/Bicep.LocalDeploy.DocGenerator.Tests/DocGeneratorTests.cs#L428,0)
at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()
at NUnit.Framework.Internal.MessagePumpStrategy.NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter awaiter)
at NUnit.Framework.Internal.AsyncToSyncAdapter.Await[TResult](TestExecutionContext context, Func`1 invoke)
at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(TestExecutionContext context, Func`1 invoke)
at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
at NUnit.Framework.Internal.Execution.SimpleWorkItem.<>c__DisplayClass3_0.<PerformWork>b__0()
at NUnit.Framework.Internal.ContextUtils.<>c__DisplayClass1_0`1.<DoIsolated>b__0(Object _)
at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
at NUnit.Framework.Internal.ContextUtils.DoIsolated(ContextCallback callback, Object state)
at NUnit.Framework.Internal.ContextUtils.DoIsolated[T](Func`1 func)
at NUnit.Framework.Internal.Execution.SimpleWorkItem.PerformWork()
at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
at System.Linq.Enumerable.SpanToDictionary[TSource,TKey,TElement](ReadOnlySpan`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector)
at Bicep.LocalDeploy.DocGenerator.Services.DocumentationGenerator.GenerateAsync(GenerationOptions options) (file:///bicep-local-docgen/src/Bicep.LocalDeploy.DocGenerator/Services/DocumentationGenerator.cs#L41,0)
at Bicep.LocalDeploy.DocGenerator.Tests.DocGeneratorTests.GenerateMarkdownFilesAsync(String csSource) (file:///bicep-local-docgen/src/Bicep.LocalDeploy.DocGenerator.Tests/DocGeneratorTests.cs#L33,0)
at Bicep.LocalDeploy.DocGenerator.Tests.DocGeneratorTests.DuplicateClassNameUniqueResourceNames() (file:///bicep-local-docgen/src/Bicep.LocalDeploy.DocGenerator.Tests/DocGeneratorTests.cs#L428,0)
at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()
at NUnit.Framework.Internal.MessagePumpStrategy.NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter awaiter)
at NUnit.Framework.Internal.AsyncToSyncAdapter.Await[TResult](TestExecutionContext context, Func`1 invoke)
at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(TestExecutionContext context, Func`1 invoke)
at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
at NUnit.Framework.Internal.Execution.SimpleWorkItem.<>c__DisplayClass3_0.<PerformWork>b__0()
at NUnit.Framework.Internal.ContextUtils.<>c__DisplayClass1_0`1.<DoIsolated>b__0(Object _)
at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
at NUnit.Framework.Internal.ContextUtils.DoIsolated(ContextCallback callback, Object state)
at NUnit.Framework.Internal.ContextUtils.DoIsolated[T](Func`1 func)
at NUnit.Framework.Internal.Execution.SimpleWorkItem.PerformWork()
```